### PR TITLE
Working on latest minetest

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -29,6 +29,7 @@ if simple_skins == true then
 	--change the player's hand to their skin
 	minetest.register_on_joinplayer(function(player)
 		local skin = skins.skins[player:get_player_name()]
+		player:get_inventory():set_size("hand", 1)
 		player:get_inventory():set_stack("hand", 1, "newhand:"..skin)
 	end)
 	

--- a/init.lua
+++ b/init.lua
@@ -40,7 +40,8 @@ if simple_skins == true then
 			local skin = skins.skins[name]
 			
 			if skin ~= newhand_oldskin[name] then
-				player:get_inventory():set_stack("hand", 1, "newhand:"..skin)
+                          player:get_inventory():set_size("hand", 1)
+                          player:get_inventory():set_stack("hand", 1, "newhand:"..skin)
 			end
 			
 			newhand_oldskin[name] = skin
@@ -67,6 +68,7 @@ else
 	})
 
 	minetest.register_on_joinplayer(function(player)
+		player:get_inventory():set_size("hand", 1)
 		player:get_inventory():set_stack("hand", 1, "newhand:hand")
 	end)
 end


### PR DESCRIPTION
Hi, I really like this mod. Thanks for this awesome job

In the latest minetest hand inventory size is 0 by default so you have to set it to 1 to set a hand skin
This is a security feature because prevent users from get any item of the world using it
https://github.com/minetest/minetest/issues/8559

For now I think the way to make it more secure and be able to use public is modify allow_put to only accepts hand nodes