### PR TITLE
move redundant code into functions. Fix warnings with Minetest 5.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # newhand
 a mod which makes the hand 3d in minetest
+
+
+# API
+Any player skin mod can integrate the hand using this API
+- newhand.register_hand(hand, texture)
+  - name - Hand (node) name. Should match mod:name_xyz
+  - texture - skin texture
+
+- newhand.set_hand(player, hand)
+  - player - Player object
+  - hand - Hand (node) name

--- a/init.lua
+++ b/init.lua
@@ -1,4 +1,6 @@
-local function register_hand(name, texture)
+newhand = {}
+
+function newhand.register_hand(name, texture)
 	minetest.register_node(name, {
 		description = "",
 		tiles = {texture},
@@ -19,13 +21,17 @@ local function register_hand(name, texture)
 end
 
 local oldhand = {}
-local function set_hand(player, hand)
+
+function newhand.set_hand(player, hand)
 	local name = player:get_player_name()
 	if hand ~= oldhand[name] then
-		player:get_inventory():set_size("hand", 1)
-		player:get_inventory():set_stack("hand", 1, hand)
+		if hand and minetest.registered_nodes[hand] then
+			player:get_inventory():set_size("hand", 1)
+			player:get_inventory():set_stack("hand", 1, hand)
+		else
+			player:get_inventory():set_size("hand", 0)
+		end
 	end
-
 	oldhand[name] = hand
 end
 
@@ -33,7 +39,7 @@ end
 if minetest.get_modpath("simple_skins") then
 	--generate a node for every skin
 	for _,texture in pairs(skins.list) do
-		register_hand("newhand:"..texture, texture..".png")
+		newhand.register_hand("newhand:"..texture, texture..".png")
 	end
 
 	--change the player's hand to their skin
@@ -46,14 +52,14 @@ if minetest.get_modpath("simple_skins") then
 	minetest.register_globalstep(function(dtime)
 		for _,player in ipairs(minetest.get_connected_players()) do
 			local skin = skins.skins[player:get_player_name()]
-			set_hand(player, "newhand:"..skin)
+			newhand.set_hand(player, "newhand:"..skin)
 		end
 	end)
 
 --do default skin if no skin mod installed
 else
-	register_hand("newhand:hand", "character.png")
+	newhand.register_hand("newhand:hand", "character.png")
 	minetest.register_on_joinplayer(function(player)
-		set_hand(player, "newhand:hand")
+		newhand.set_hand(player, "newhand:hand")
 	end)
 end

--- a/init.lua
+++ b/init.lua
@@ -1,56 +1,7 @@
---print(dump(skins.list))
-
-local simple_skins = minetest.get_modpath("simple_skins") ~= nil
-
-
-
---simple skins is enabled
-if simple_skins == true then
-	newhand_oldskin = {}
-	--generate a node for every skin
-	for _,texture in pairs(skins.list) do
-		minetest.register_node("newhand:"..texture, {
-			description = "",
-			tiles = {texture..".png"},
-			inventory_image = "newhand_inv.png",
-			on_place = function(itemstack, placer, pointed_thing)
-				if minetest.get_node(pointed_thing.under).name == "default:chest_locked" then
-					minetest.item_place(itemstack, placer, pointed_thing, param2)
-				end
-			end,
-			visual_scale = 1,
-			wield_scale = {x=1,y=1,z=1},
-			paramtype = "light",
-			drawtype = "mesh",
-			mesh = "hand.b3d",
-			node_placement_prediction = "",
-		})
-	end
-	--change the player's hand to their skin
-	minetest.register_on_joinplayer(function(player)
-		local skin = skins.skins[player:get_player_name()]
-		player:get_inventory():set_stack("hand", 1, "newhand:"..skin)
-	end)
-	
-	--check to update the skin
-	minetest.register_globalstep(function(dtime)
-		for _,player in ipairs(minetest.get_connected_players()) do
-			local name = player:get_player_name()
-			local skin = skins.skins[name]
-			
-			if skin ~= newhand_oldskin[name] then
-				player:get_inventory():set_stack("hand", 1, "newhand:"..skin)
-			end
-			
-			newhand_oldskin[name] = skin
-		end
-	end)
-	
---do default skin if no skin mod installed
-else
-	minetest.register_node("newhand:hand", {
+local function register_hand(name, texture)
+	minetest.register_node(name, {
 		description = "",
-		tiles = {"character.png"},
+		tiles = {texture},
 		inventory_image = "newhand_inv.png",
 		on_place = function(itemstack, placer, pointed_thing)
 			if minetest.get_node(pointed_thing.under).name == "default:chest_locked" then
@@ -63,9 +14,46 @@ else
 		drawtype = "mesh",
 		mesh = "hand.b3d",
 		node_placement_prediction = "",
+		use_texture_alpha = "clip"
 	})
+end
 
+local oldhand = {}
+local function set_hand(player, hand)
+	local name = player:get_player_name()
+	if hand ~= oldhand[name] then
+		player:get_inventory():set_size("hand", 1)
+		player:get_inventory():set_stack("hand", 1, hand)
+	end
+
+	oldhand[name] = hand
+end
+
+--simple skins is enabled
+if minetest.get_modpath("simple_skins") then
+	--generate a node for every skin
+	for _,texture in pairs(skins.list) do
+		register_hand("newhand:"..texture, texture..".png")
+	end
+
+	--change the player's hand to their skin
 	minetest.register_on_joinplayer(function(player)
-		player:get_inventory():set_stack("hand", 1, "newhand:hand")
+		local skin = skins.skins[player:get_player_name()]
+		player:get_inventory():set_stack("hand", 1, "newhand:"..skin)
+	end)
+
+	--check to update the skin
+	minetest.register_globalstep(function(dtime)
+		for _,player in ipairs(minetest.get_connected_players()) do
+			local skin = skins.skins[player:get_player_name()]
+			set_hand(player, "newhand:"..skin)
+		end
+	end)
+
+--do default skin if no skin mod installed
+else
+	register_hand("newhand:hand", "character.png")
+	minetest.register_on_joinplayer(function(player)
+		set_hand(player, "newhand:hand")
 	end)
 end

--- a/mod.conf
+++ b/mod.conf
@@ -1,1 +1,2 @@
 name = newhand
+optional_depends = simple_skins


### PR DESCRIPTION
Moved redundant code into functions for better expandability.
Added use_texture_alpha = "clip" to avoid warinigs on Minetest 5.5
Added dependency to mod.conf
Applied the #11 is included in this change
Some cleanup
Add API for integration into misc skins mods